### PR TITLE
feat(plugin): Now ignored routes will also ignore if trailing slash present

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,8 +13,9 @@ function htmlWasRequested(request) {
 }
 
 function pathShouldNotBeExcluded(excludedRoutes, path) {
+  const pathWithoutTrailingSlash = path.slice(-1) === '/' ? path.slice(0, -1) : path;
   if (excludedRoutes) {
-    return !excludedRoutes.includes(path);
+    return !excludedRoutes.includes(pathWithoutTrailingSlash);
   }
 
   return true;

--- a/test/unit/plugin-test.js
+++ b/test/unit/plugin-test.js
@@ -87,6 +87,16 @@ suite('plugin', () => {
     assert.notCalled(request.setUrl);
   });
 
+  test('that excluded routes also exclude trailing slash', () => {
+    const excludedRoute = `/${any.word()}`;
+    request.path = `${excludedRoute}/`;
+    mediaType.returns('text/html');
+
+    router.register(server, {excludedRoutes: [excludedRoute]}, next);
+
+    assert.notCalled(request.setUrl);
+  });
+
   test('that verbs other than GET are not transformed', () => {
     request.method = any.word();
     mediaType.returns('text/html');


### PR DESCRIPTION
Previously if we had ignored something like `/foo`, hitting the endpoint `/foo/` would not be
ignored. This will now be ignored.

closes travi/hapi-html-request-router#96