### PR TITLE
feat(plugin): Added ability to exclude routes based on regex

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,9 +12,13 @@ function htmlWasRequested(request) {
   return 'text/html' === negotiator.mediaType();
 }
 
+function findMatchedRoutes(excludedRoutes, path) {
+  return excludedRoutes.map(route => path.match(route)).filter(Boolean);
+}
+
 function pathShouldNotBeExcluded(excludedRoutes, path) {
   if (excludedRoutes) {
-    return !excludedRoutes.includes(path);
+    return 0 === findMatchedRoutes(excludedRoutes, path).length;
   }
 
   return true;

--- a/test/unit/plugin-test.js
+++ b/test/unit/plugin-test.js
@@ -87,6 +87,16 @@ suite('plugin', () => {
     assert.notCalled(request.setUrl);
   });
 
+  test('that routes can be excluded by regex', () => {
+    const excludedRoute = '/foo/*';
+    request.path = '/foo/bar/baz';
+    mediaType.returns('text/html');
+
+    router.register(server, {excludedRoutes: [excludedRoute]}, next);
+
+    assert.notCalled(request.setUrl);
+  });
+
   test('that verbs other than GET are not transformed', () => {
     request.method = any.word();
     mediaType.returns('text/html');


### PR DESCRIPTION
You can now exclude routes by something like `/foo/*` to exclude `/foo/bar` & `/foo/bar/baz`, etc.

closes travi/hapi-html-request-router#97